### PR TITLE
Feature: Backup solution adjusted

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ Get all items that are on the queue:
 
 ```js
 queue.items(function(err, items) {
-  console.log('There are the following items on the queue:', queue);
+  console.log('There are the following items on the queue:', items);
+});
+```
+
+Get all items that are in progress:
+
+```js
+queue.itemsInProgress(function(err, progress) {
+  console.log('There are the following items on the queue:', progress);
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ OST offers an `each` method that yields to a block for every new entry on the qu
 
 About enqueue/dequeue: In the parlance of Redis, enqueue is `lpush` and dequeue is `rpop`. But I prefer to use the terminology used for the abstract data type [queue](https://en.wikipedia.org/wiki/Queue_(abstract_data_type)).
 
-Kute keeps entries that are being processed with one central `backup` list (opposed to Kute, which uses [one per worker](https://github.com/soveran/ost#failures) as suggested in the [reliable queue pattern](http://redis.io/commands/rpoplpush#pattern-reliable-queue). If a consumer reports an error in the `done` callback, the entry will not be removed from the backup list. You can monitor the backup list to keep track of entries that stay in there too long (because the worker crashed or ran into an error).
+Kute keeps entries that are being processed with one central `progress` list (opposed to Kute, which uses [one per worker](https://github.com/soveran/ost#failures) as suggested in the [reliable queue pattern](http://redis.io/commands/rpoplpush#pattern-reliable-queue). If a consumer reports an error in the `done` callback, the entry will not be removed from the progress list. You can monitor the progress list to keep track of entries that stay in there too long (because the worker crashed or ran into an error).
 
 ## Anti-Features
 
@@ -76,7 +76,7 @@ You might say: "Hu? A queue based on Redis? But... But... Redis is not a queue!"
 * **Only a message, no data:** Your worker knows how to get the data. It could access the database for that or you could use something like [storage-pod](https://github.com/moonglum/storage-pod).
 * **No events for finished or failed events:** You can use Redis PubSub if you need it. If you need that feature it could also mean that you should use a [MOM](https://en.wikipedia.org/wiki/Message_oriented_middleware).
 * **No monitoring:** And you might not need it. We for example use a central logging and monitoring solution to see the throughput of our queue etc.
-* **No retries:** But you could implement that by monitoring the `backup` list.
+* **No retries:** But you could implement that by monitoring the `progress` list.
 * **No priorities**
 * **No delayed jobs or scheduling.**
 * **No web interface.**

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ Queue.prototype.size = function(cb) {
   this.redis.llen([this.key], cb);
 };
 
+Queue.prototype.itemsInProgress = function(cb) {
+  this.redis.lrange([this.progress, 0, -1], cb);
+};
+
 exports.Queue = Queue;
 
 exports.queue = function(name) {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var nido = function(arr) { return arr.join(':'); };
 
 var Queue = function(name, redis, timeout) {
   this.key = nido(['ost', name]);
-  this.backup = nido(['ost', name, 'backup']);
+  this.progress = nido(['ost', name, 'progress']);
   this.redis = redis;
   this.timeout = timeout;
 };
@@ -14,9 +14,9 @@ Queue.prototype.enqueue = function(value, cb) {
 
 Queue.prototype.dequeue = function(cb) {
   var redis = this.redis;
-  var backup = this.backup;
+  var progress = this.progress;
 
-  this.redis.brpoplpush([this.key, this.backup, this.timeout], function(err, reply) {
+  this.redis.brpoplpush([this.key, this.progress, this.timeout], function(err, reply) {
     if (err) {
       cb(err);
       return;
@@ -25,7 +25,7 @@ Queue.prototype.dequeue = function(cb) {
     if (reply) {
       cb(null, reply, function(consumerError) {
         if (!consumerError) {
-          redis.lrem([backup, 1, reply], function() {});
+          redis.lrem([progress, 1, reply], function() {});
         }
       });
     } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kute",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A minimalistic queue library based on Redis inspired by OST",
   "main": "index.js",
   "dependencies": {},

--- a/test.js
+++ b/test.js
@@ -68,8 +68,7 @@ test('Remove from `progress` when worker succeeded', function(t) {
   consumer.dequeue(function(error, message, done) {
     done();
 
-    consumerClient.lrange([consumer.progress, 0, -1], function(listError, progress) {
-      console.log(listError);
+    consumer.itemsInProgress(function(listError, progress) {
       t.deepEqual(progress, []);
       t.end();
       consumerClient.quit();
@@ -91,7 +90,7 @@ test('Keep in `progress` when worker failed', function(t) {
   consumer.dequeue(function(error, message, done) {
     done(new Error('oh no'));
 
-    consumerClient.lrange([consumer.progress, 0, -1], function(listError, progress) {
+    consumer.itemsInProgress(function(listError, progress) {
       t.deepEqual(progress, [ 'mymessage' ]);
       t.end();
       consumerClient.quit();

--- a/test.js
+++ b/test.js
@@ -58,7 +58,7 @@ test('Items', function(t) {
   });
 });
 
-test('Keep no Backup when worker succeeded', function(t) {
+test('Remove from `progress` when worker succeeded', function(t) {
   var producerClient = require('redis').createClient();
   var consumerClient = require('redis').createClient();
 
@@ -68,9 +68,9 @@ test('Keep no Backup when worker succeeded', function(t) {
   consumer.dequeue(function(error, message, done) {
     done();
 
-    consumerClient.lrange([consumer.backup, 0, -1], function(listError, backup) {
+    consumerClient.lrange([consumer.progress, 0, -1], function(listError, progress) {
       console.log(listError);
-      t.deepEqual(backup, []);
+      t.deepEqual(progress, []);
       t.end();
       consumerClient.quit();
     });
@@ -81,7 +81,7 @@ test('Keep no Backup when worker succeeded', function(t) {
   });
 });
 
-test('Keep Backup when worker failed', function(t) {
+test('Keep in `progress` when worker failed', function(t) {
   var producerClient = require('redis').createClient();
   var consumerClient = require('redis').createClient();
 
@@ -91,8 +91,8 @@ test('Keep Backup when worker failed', function(t) {
   consumer.dequeue(function(error, message, done) {
     done(new Error('oh no'));
 
-    consumerClient.lrange([consumer.backup, 0, -1], function(listError, backup) {
-      t.deepEqual(backup, [ 'mymessage' ]);
+    consumerClient.lrange([consumer.progress, 0, -1], function(listError, progress) {
+      t.deepEqual(progress, [ 'mymessage' ]);
       t.end();
       consumerClient.quit();
     });


### PR DESCRIPTION
As noted in the README, the solution for backups was not suited for the usage with multiple workers. So instead, there is now one central place for all backups and the entries are removed with `LREM` as suggested in the [Reliable Queue Pattern](http://redis.io/commands/rpoplpush#pattern-reliable-queue). Also the backup is renamed to `progress` and you can receive the progress list with a simple method call.
