### PR TITLE
Feature: Enhance options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,16 @@ Enqueue an entry:
 
 ```js
 var producerClient = require('redis').createClient();
-var producer = new Queue('queuename', producerClient, 2);
+var producer = new Queue('queuename', producerClient);
 producer.enqueue('mymessage', function(error) {
 });
 ```
-
-The error can either be an error coming from Redis or a `TimeoutError` (if you set the timeout to something other than 0).
 
 Dequeue an entry:
 
 ```js
 var consumerClient = require('redis').createClient();
-var consumer = new Queue('queuename', consumerClient, 2);
+var consumer = new Queue('queuename', consumerClient);
 consumer.dequeue(function(error, entry, done) {
   console.log('I just got the entry "', entry, '" from the queue');
   done();
@@ -38,7 +36,7 @@ Dequeue an entry and hit an error:
 
 ```js
 var consumerClient = require('redis').createClient();
-var consumer = new Queue('queuename', consumerClient, 2);
+var consumer = new Queue('queuename', consumerClient);
 consumer.dequeue(function(error, entry, done) {
   console.log('I had an error while processing');
   done(new Error('darn it'));
@@ -70,6 +68,12 @@ queue.itemsInProgress(function(err, progress) {
 ```
 
 By the way: You can also consume entries created by OST or create entries to be consumed by OST (This is the reason it uses an `ost` prefix in Redis instead of a `kute` prefix).
+
+### Options
+
+You can provide optional parameters in the form of an Object as a third argument to the Queue constructor:
+
+* `timeout`: If you want the `dequeue` operation to time out after not receiving a job for a certain time (because no one enqueued any values), you can set this option to a value in seconds. Per default, there is no timeout. If you run into a Timeout, you will receive a `TimeoutError` as the first argument to your `dequeue` handler.
 
 ## Differences to OST (and other queues)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ By the way: You can also consume entries created by OST or create entries to be 
 You can provide optional parameters in the form of an Object as a third argument to the Queue constructor:
 
 * `timeout`: If you want the `dequeue` operation to time out after not receiving a job for a certain time (because no one enqueued any values), you can set this option to a value in seconds. Per default, there is no timeout. If you run into a Timeout, you will receive a `TimeoutError` as the first argument to your `dequeue` handler.
+* `prefix`: The default `prefix` of the created Redis entries is `ost`, but you can change it with this option.
 
 ## Differences to OST (and other queues)
 

--- a/examples/consumer.js
+++ b/examples/consumer.js
@@ -5,7 +5,7 @@ var Queue = require('../').Queue;
 
 var workerPool = new EventEmitter();
 workerPool.setMaxListeners(1);
-var queue = new Queue('a', client, 2);
+var queue = new Queue('a', client);
 
 var publish = function(error, result) {
   if (error) {

--- a/examples/producer.js
+++ b/examples/producer.js
@@ -1,6 +1,6 @@
 var client = require('redis').createClient();
 var Queue = require('../').Queue;
-var queue = new Queue('a', client, 2);
+var queue = new Queue('a', client);
 
 queue.enqueue('test message', function() {
   process.exit();

--- a/index.js
+++ b/index.js
@@ -7,11 +7,12 @@ var TimeoutError = function(message) {
 };
 inherits(TimeoutError, Error);
 
-var Queue = function(name, redis, timeout) {
+var Queue = function(name, redis, opts) {
+  opts = opts || {};
   this.key = nido(['ost', name]);
   this.progress = nido(['ost', name, 'progress']);
   this.redis = redis;
-  this.timeout = timeout;
+  this.timeout = opts.timeout || 0;
 };
 
 Queue.prototype.enqueue = function(value, cb) {

--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ inherits(TimeoutError, Error);
 
 var Queue = function(name, redis, opts) {
   opts = opts || {};
-  this.key = nido(['ost', name]);
-  this.progress = nido(['ost', name, 'progress']);
+  var prefix = opts.prefix || 'ost';
+  this.key = nido([prefix, name]);
+  this.progress = nido([prefix, name, 'progress']);
   this.redis = redis;
   this.timeout = opts.timeout || 0;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kute",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "A minimalistic queue library based on Redis inspired by OST",
   "main": "index.js",
   "dependencies": {},

--- a/test.js
+++ b/test.js
@@ -8,8 +8,8 @@ test('Push and Pop', function(t) {
   var producerClient = require('redis').createClient();
   var consumerClient = require('redis').createClient();
 
-  var producer = new Queue(prefix + 'pnp', producerClient, 2);
-  var consumer = new Queue(prefix + 'pnp', consumerClient, 2);
+  var producer = new Queue(prefix + 'pnp', producerClient, { timeout: 2 });
+  var consumer = new Queue(prefix + 'pnp', consumerClient, { timeout: 2 });
 
   consumer.dequeue(function(error, message, done) {
     done();
@@ -26,7 +26,7 @@ test('Push and Pop', function(t) {
 test('Size', function(t) {
   var producerClient = require('redis').createClient();
 
-  var producer = new Queue(prefix + 'size', producerClient, 2);
+  var producer = new Queue(prefix + 'size', producerClient, { timeout: 2 });
 
   producer.size(function(err, size) {
     t.equal(size, 0);
@@ -44,7 +44,7 @@ test('Size', function(t) {
 test('Items', function(t) {
   var producerClient = require('redis').createClient();
 
-  var producer = new Queue(prefix + 'items', producerClient, 2);
+  var producer = new Queue(prefix + 'items', producerClient, { timeout: 2 });
 
   producer.items(function(err, items) {
     t.deepEqual(items, []);
@@ -63,8 +63,8 @@ test('Remove from `progress` when worker succeeded', function(t) {
   var producerClient = require('redis').createClient();
   var consumerClient = require('redis').createClient();
 
-  var producer = new Queue(prefix + 'emptybu', producerClient, 2);
-  var consumer = new Queue(prefix + 'emptybu', consumerClient, 2);
+  var producer = new Queue(prefix + 'emptybu', producerClient, { timeout: 2 });
+  var consumer = new Queue(prefix + 'emptybu', consumerClient, { timeout: 2 });
 
   consumer.dequeue(function(error, message, done) {
     done();
@@ -85,8 +85,8 @@ test('Keep in `progress` when worker failed', function(t) {
   var producerClient = require('redis').createClient();
   var consumerClient = require('redis').createClient();
 
-  var producer = new Queue(prefix + 'bu', producerClient, 2);
-  var consumer = new Queue(prefix + 'bu', consumerClient, 2);
+  var producer = new Queue(prefix + 'bu', producerClient, { timeout: 2 });
+  var consumer = new Queue(prefix + 'bu', consumerClient, { timeout: 2 });
 
   consumer.dequeue(function(error, message, done) {
     done(new Error('oh no'));
@@ -105,7 +105,7 @@ test('Keep in `progress` when worker failed', function(t) {
 
 test('Timeout', function(t) {
   var consumerClient = require('redis').createClient();
-  var consumer = new Queue(prefix + 'timeout', consumerClient, 1);
+  var consumer = new Queue(prefix + 'timeout', consumerClient, { timeout: 1 });
 
   consumer.dequeue(function(error) {
     t.ok(error instanceof TimeoutError, 'Should be a TimeoutError');

--- a/test.js
+++ b/test.js
@@ -114,6 +114,18 @@ test('Timeout', function(t) {
   });
 });
 
+test('Name of the key', function(t) {
+  var client = require('redis').createClient();
+  var q1 = new Queue('test', client);
+  t.equal(q1.key, 'ost:test');
+
+  var q2 = new Queue('test', client, { prefix: 'kute' });
+  t.equal(q2.key, 'kute:test');
+
+  t.end();
+  client.quit();
+});
+
 test('Examples', function(t) {
   var consumer = childProcess.spawn('node', ['examples/consumer.js']);
 


### PR DESCRIPTION
Take an options object as the third argument instead of the timeout option. The options are:
- `timeout`: If you want the `dequeue` operation to time out after not receiving a job for a certain time (because no one enqueued any values), you can set this option to a value   in seconds. Per default, there is no timeout. If you run into a Timeout, you will receive a `TimeoutError` as the first argument to your `dequeue` handler.
- `prefix`: The default `prefix` of the created Redis entries is `ost`, but you can change it with this option.
